### PR TITLE
顧客登録とログイン画面の作成

### DIFF
--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Public::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_permitted_parameters, if: :devise_controller?
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
@@ -51,12 +52,19 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
+  # 新規登録後はマイページへ
+  def after_sign_up_path_for(resource)
+    super(resource)
+      customers_path
+  end
+  
+  protected
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:family_name, :first_name,
+    :family_name_kana, :first_name_kana, :post_code, :address, :phone_number] )
+  end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,4 +3,12 @@ class Customer < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :family_name,length: { in: 1..10 }
+  validates :first_name,length: { in: 1..10 }
+  validates :family_name_kana,length: { in: 1..10 }
+  validates :first_name_kana,length: { in: 1..10 }
+  validates :post_code, presence: true
+  validates :address, presence: true
+  validates :phone_number, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,8 @@
   </head>
 
   <body>
+    <p class="notice"><%= notice %></p>
+    <p class="alert"><%= alert %></p>
     <%= yield %>
   </body>
 </html>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,29 +1,109 @@
-<h2>Sign up</h2>
+<%= render "public/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
+<h4>新規会員登録</h4>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+<%= form_with model: @customer do |f| %>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+  <table class="table table-borderless">
+    <tr>
+      <td>
+        <p>名前</p>
+      </td>
+      <td>
+        <div class="form_group">
+          <%= f.label :family_name , "(姓)"%>
+          <%= f.text_field :family_name ,class: "form_control", placeholder: "令和" %>
+        </div>
+      </td>
+      <td>
+        <div class="form_group">
+          <%= f.label :first_name , "(名)"%>
+          <%= f.text_field :first_name ,class: "form_control", placeholder: "道子" %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p>フリガナ</p>
+      </td>
+      <td>
+        <div class="form_group">
+          <%= f.label :family_name_kana, "(セイ)"%>
+          <%= f.text_field :family_name_kana ,class: "form_control", placeholder: "レイワ" %>
+        </div>
+      </td>
+      <td>
+        <div class="form_group">
+          <%= f.label :first_name_kana , "(メイ)"%>
+          <%= f.text_field :first_name_kana ,class: "form_control", placeholder: "ミチコ" %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <div class="form_group">
+        <td>
+          <%= f.label :email , "メールアドレス"%>
+        </td>
+        <td>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" ,class: "form_control", placeholder: "sample@example.com" %>
+        </td>
+      </div>
+    </tr>
+    <tr>
+      <div class="form_group">
+        <td>
+          <%= f.label :post_code , "郵便番号(ハイフンなし)"%>
+        </td>
+        <td>
+          <%= f.text_field :post_code,class: "form_control", placeholder: "0000000" %>
+        </td>
+      </div>
+    </tr>
+    <tr>
+      <div class="form_group">
+        <td>
+          <%= f.label :address , "住所"%>
+        </td>
+        <td>
+          <%= f.text_field :address , class: "form_control",size: "60", placeholder: "東京都渋谷区代々木神園町0-0" %>
+        </td>
+      </div>
+    </tr>
+    <tr>
+      <div class="form_group">
+        <td>
+          <%= f.label :phone_number , "電話番号(ハイフンなし)"%>
+        </td>
+        <td>
+          <%= f.text_field :phone_number , class: "form_control", placeholder: "0000000000" %>
+        </td>
+      </div>
+    </tr>
+    <tr>
+      <div class="form_group">
+        <td>
+          <%= f.label :password , "パスワード(6文字以上)"%>
+        </td>
+        <td>
+          <%= f.password_field :password, autocomplete: "new-password" ,class: "form_control" %>
+        </td>
+      </div>
+    </tr>
+    <tr>
+      <div class="form_group">
+        <td>
+          <%= f.label :password_confirmation , "パスワード(確認用)"%>
+        </td>
+        <td>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form_control" %>
+        </td>
+      </div>
+    </tr>
+  </table>
+<div class="actions">
+  <%= f.submit "新規登録", class: "btn btn-success" %>
+</div>
+<%end%>
+<p3>既に登録済みの方</p3>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+<p><%= render "public/shared/links" %>　からログインしてください。</p>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,26 +1,34 @@
-<h2>Log in</h2>
 
+<h4>ログイン</h4>
+<p>会員の方はこちらからログイン</p>
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
+  <table class="table table-borderless">
+    <tr>
+      <div class="field">
+        <td>
+          <%= f.label :email, "メールアドレス" %>
+        </td>
+        <td>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",placeholder: "sample@example.com" %>
+        </td>
+      </div>
+    </tr>
+    <tr>
+      <div class="field">
+        <td>
+        <%= f.label :password, "パスワード" %>
+        </td>
+        <td>
+        <%= f.password_field :password, autocomplete: "current-password" %>
+        </td>
+      </div>
+    </tr>
+  </table>
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン", class: "btn btn-primary" %>
   </div>
 <% end %>
+<p>会員登録がお済みでない方</p>
+<p><%= render "public/shared/links" %>　から新規登録を行ってください。</p>
 
-<%= render "public/shared/links" %>
+

--- a/app/views/public/shared/_links.html.erb
+++ b/app/views/public/shared/_links.html.erb
@@ -1,8 +1,8 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "こちら", new_session_path(resource_name) %>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "こちら", new_registration_path(resource_name) %>
 <% end %>
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,132 @@
+ja:
+  errors:
+    messages:
+      not_saved: "エラーにより登録できません"
+  activerecord:
+    errors:
+      models:
+        customer:
+          attributes:
+            family_name:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            first_name:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            family_name_kana:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            first_name_kana:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            email:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            post_code:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            address:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            phone_number:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+              confirmation: "が内容とあっていません。"
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        name: 名前
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "次回から自動的にログイン"
+    models:
+      user: "ユーザ"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"
+    failure:
+      invalid: "メールアドレスまたはパスワードが正しくありません。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,3 +4,15 @@ ja:
       payment_method:
         credit_card: "クレジットカード"
         transfer: "銀行振込"
+  activerecord:
+    attributes:
+      customer:
+        family_name: "名前（姓）"
+        first_name: "名前（名）"
+        family_name_kana: "名前（セイ）"
+        first_name_kana: "名前（メイ）"
+        email: "メールアドレス"
+        post_code: "郵便番号"
+        address: "住所"
+        phone_number: "電話番号"
+        password: "パスワード"

--- a/db/migrate/20230716084001_devise_create_customers.rb
+++ b/db/migrate/20230716084001_devise_create_customers.rb
@@ -36,7 +36,7 @@ class DeviseCreateCustomers < ActiveRecord::Migration[6.1]
       t.string :first_name
       t.string :family_name_kana
       t.string :first_name_kana
-      t.string :posy_code
+      t.string :post_code
       t.string :address
       t.string :phone_number
       t.boolean :is_deleted, default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 2023_07_17_073843) do
     t.string "first_name"
     t.string "family_name_kana"
     t.string "first_name_kana"
-    t.string "posy_code"
+    t.string "post_code"
     t.string "address"
     t.string "phone_number"
     t.boolean "is_deleted", default: false, null: false


### PR DESCRIPTION
顧客の登録画面とログイン画面です

・機能の設定（氏名入力欄などの追加）
・サインアップ後の画面遷移設定
・バリデーションの設定
・エラーメッセージの日本語化
・dbも少しいじりましたposy_code→post_code
（↑プルした後db:migrate:reset必要の可能性あり）